### PR TITLE
Fix originator errors

### DIFF
--- a/rec_to_nwb/processing/builder/nwb_file_builder.py
+++ b/rec_to_nwb/processing/builder/nwb_file_builder.py
@@ -301,11 +301,6 @@ class NWBFileBuilder:
 
         self.epochs_originator.make(nwb_content)
 
-        self.processing_module_originator.make(nwb_content)
-
-        self.position_originator.make(nwb_content)
-
-        self.video_files_originator.make(nwb_content)
         self.sample_count_timestamp_corespondence_originator.make(nwb_content)
 
         self.task_originator.make(nwb_content)

--- a/rec_to_nwb/processing/builder/nwb_file_builder.py
+++ b/rec_to_nwb/processing/builder/nwb_file_builder.py
@@ -310,6 +310,9 @@ class NWBFileBuilder:
         if self.process_dio:
             self.dio_originator.make(nwb_content)
 
+        if self.process_mda:
+            self.mda_originator.make(nwb_content)
+
         if self.process_analog:
             self.analog_originator.make(nwb_content)
 


### PR DESCRIPTION
This fixes recently introduced errors in NWBFileBuilder.build():
- there were duplicate calls to some originators, which attempted to create the same processing module twice and gave errors;
- and a missing call to MDA originator, which resulted in a nwbfile that does not included the e-series.