### PR TITLE
Add preprocessing options

### DIFF
--- a/rec_to_nwb/environment.yml
+++ b/rec_to_nwb/environment.yml
@@ -49,7 +49,7 @@ dependencies:
   - pip:
       - mountainlab_pytools
       - xmldiff
-      - rec-to-binaries==0.6.0.dev0
+      - rec-to-binaries==0.6.1.dev0
       - hdmf>2.1.0
       - pynwb
 

--- a/rec_to_nwb/processing/builder/nwb_file_builder.py
+++ b/rec_to_nwb/processing/builder/nwb_file_builder.py
@@ -159,9 +159,10 @@ class NWBFileBuilder:
             self.header = Header(reconfig_header)
         else:
             self.header = Header(header_file)
-        self.data_scanner = DataScanner(data_path, animal_name, nwb_metadata)
+        self.data_scanner = DataScanner(self.preprocessing_path, animal_name, nwb_metadata)
         self.dataset_names = self.data_scanner.get_all_epochs(date)
-        full_data_path = data_path + '/' + animal_name + '/preprocessing/' + date
+        full_data_path = os.path.join(self.preprocessing_path, 
+                                    animal_name + '/preprocessing/' + date)
 
         validation_registrator = ValidationRegistrator()
         validation_registrator.register(NTrodeValidator(self.metadata, self.header, self.probes))

--- a/rec_to_nwb/processing/builder/nwb_file_builder.py
+++ b/rec_to_nwb/processing/builder/nwb_file_builder.py
@@ -88,6 +88,7 @@ class NWBFileBuilder:
             process_mda: bool = True,
             process_analog: bool = True,
             process_pos_timestamps: bool = True,
+            preprocessing_path: str = '',
             video_path: str = '',
             output_file: str = 'output.nwb',
             reconfig_header: str = ''
@@ -127,6 +128,10 @@ class NWBFileBuilder:
         self.process_mda = process_mda
         self.process_analog = process_analog
         self.process_pos_timestamps = process_pos_timestamps
+        if not preprocessing_path:
+            self.preprocessing_path = data_path
+        else:
+            self.preprocessing_path = preprocessing_path
         self.output_file = output_file
         self.video_path = video_path
         self.link_to_notes = self.metadata.get('link to notes', None)

--- a/rec_to_nwb/processing/builder/nwb_file_builder.py
+++ b/rec_to_nwb/processing/builder/nwb_file_builder.py
@@ -148,7 +148,13 @@ class NWBFileBuilder:
                   + self.date)
         )
 
-        header_file = HeaderProcessor.process_headers(rec_files_list)
+        if not preprocessing_path:
+            header_path = None # default
+        else:
+            header_path = (self.preprocessing_path
+                            + '/' + self.animal_name + '/headers/' + self.date)
+            os.makedirs(header_path, exist_ok=True)
+        header_file = HeaderProcessor.process_headers(rec_files_list, copy_dir=header_path)
         if reconfig_header:
             self.header = Header(reconfig_header)
         else:

--- a/rec_to_nwb/processing/builder/raw_to_nwb_builder.py
+++ b/rec_to_nwb/processing/builder/raw_to_nwb_builder.py
@@ -70,6 +70,7 @@ class RawToNWBBuilder:
             nwb_metadata: MetadataManager,
             output_path: str = '',
             video_path: str = '',
+            preprocessing_path: str = '',
             extract_analog: bool = True,
             extract_spikes: bool = False,
             extract_lfps: bool = False,
@@ -110,6 +111,10 @@ class RawToNWBBuilder:
         self.metadata = nwb_metadata.metadata
         self.output_path = output_path
         self.video_path = video_path
+        if not preprocessing_path:
+            self.preprocessing_path = data_path
+        else:
+            self.preprocessing_path = preprocessing_path
         self.probes = nwb_metadata.probes
         self.nwb_metadata = nwb_metadata
         self.parallel_instances = parallel_instances
@@ -160,6 +165,7 @@ class RawToNWBBuilder:
                 process_mda=self.extract_mda,
                 process_dio=self.extract_dio,
                 process_analog=self.extract_analog,
+                preprocessing_path=self.preprocessing_path,
                 video_path=self.video_path,
                 reconfig_header=self.__get_header_path()
                 #reconfig_header=self.__is_rec_config_valid()

--- a/rec_to_nwb/processing/builder/raw_to_nwb_builder.py
+++ b/rec_to_nwb/processing/builder/raw_to_nwb_builder.py
@@ -207,6 +207,7 @@ class RawToNWBBuilder:
         extract_trodes_rec_file(
             self.data_path,
             self.animal_name,
+            out_dir=self.preprocessing_path,
             parallel_instances=self.parallel_instances,
             extract_analog=self.extract_analog,
             extract_dio=self.extract_dio,
@@ -248,7 +249,7 @@ class RawToNWBBuilder:
     def cleanup(self):
         """Remove all temporary files structure from preprocessing folder"""
 
-        preprocessing = self.data_path + '/' + self.animal_name + '/preprocessing'
+        preprocessing = self.preprocessing_path + '/' + self.animal_name + '/preprocessing'
         if os.path.exists(preprocessing):
             shutil.rmtree(preprocessing)
 

--- a/rec_to_nwb/processing/builder/raw_to_nwb_builder.py
+++ b/rec_to_nwb/processing/builder/raw_to_nwb_builder.py
@@ -208,6 +208,7 @@ class RawToNWBBuilder:
             self.data_path,
             self.animal_name,
             out_dir=self.preprocessing_path,
+            dates=self.dates,
             parallel_instances=self.parallel_instances,
             extract_analog=self.extract_analog,
             extract_dio=self.extract_dio,

--- a/rec_to_nwb/processing/header/header_checker/header_extractor.py
+++ b/rec_to_nwb/processing/header/header_checker/header_extractor.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from rec_to_nwb.processing.header.xml_extractor import XMLExtractor
 
 
@@ -6,10 +8,15 @@ class HeaderFilesExtractor:
     def __init__(self):
         self.xml_files = []
 
-    def extract_headers_from_rec_files(self, rec_files):
+    def extract_headers_from_rec_files(self, rec_files, copy_dir=None):
         for rec_file in rec_files:
+            if copy_dir is not None:
+                rec_copy = Path(copy_dir).joinpath(rec_file.name)
+                xml_file = str(rec_copy) + '_header' + '.xml'
+            else:
+                xml_file = str(rec_file) + '_header' + '.xml'
             temp_xml_extractor = XMLExtractor(rec_path=rec_file,
-                                              xml_path=str(rec_file) + '_header' + '.xml')
+                                              xml_path=xml_file)
             temp_xml_extractor.extract_xml_from_rec_file()
-            self.xml_files.append(str(rec_file) + '_header' + '.xml')
+            self.xml_files.append(xml_file)
         return self.xml_files

--- a/rec_to_nwb/processing/header/header_checker/header_processor.py
+++ b/rec_to_nwb/processing/header/header_checker/header_processor.py
@@ -6,9 +6,9 @@ from rec_to_nwb.processing.header.header_checker.header_logger import HeaderLogg
 class HeaderProcessor:
 
     @staticmethod
-    def process_headers(rec_files_list):
+    def process_headers(rec_files_list, copy_dir=None):
         headers_extractor = HeaderFilesExtractor()
-        header_files = headers_extractor.extract_headers_from_rec_files(rec_files_list)
+        header_files = headers_extractor.extract_headers_from_rec_files(rec_files_list, copy_dir=copy_dir)
         header_comparator = HeaderComparator(header_files)
         headers_differences = header_comparator.compare()
 


### PR DESCRIPTION
Add more optional control over preprocessing paths.

- Allow to specify a different path to save preprocessed data as well as the rec_header files. This is useful when user does not have write access (or does not want to write) to the raw data directory.
    - Add `preprocessing_path` (str, optional), an optional kwarg for NWBFileBuilder or RawToNWBBuilder class.
    - If not specified, default is `data_path`, same as previous behavior.
    - If specified, the `rec_header.xml` files are also saved to this `preprocessing_path`, in a subdirectory /headers/.
- Only preprocess data from the dates that will be included in the NWB file. This is useful when the raw dataset includes data from multiple days but the user does not want to extract them all at once.
    - RawToNWBBuilder now passes the existing attribute `dates` to preprocessing, so that only the selected dates are preprocessed.

These changes depend on the recent update in `rec_to_binaries` (version 0.6.1).