### PR TITLE
Fix default header comparison

### DIFF
--- a/rec_to_nwb/processing/nwb/components/device/header/fl_header_device_manager.py
+++ b/rec_to_nwb/processing/nwb/components/device/header/fl_header_device_manager.py
@@ -13,6 +13,6 @@ class FlHeaderDeviceManager:
 
     def __compare_global_configuration_with_default(self):
         for single_key in self.default_configuration:
-            if single_key not in self.global_configuration.keys():
+            if single_key not in self.global_configuration.keys() or self.global_configuration[single_key] is None:
                 self.global_configuration[single_key] = self.default_configuration[single_key]
         return self.global_configuration


### PR DESCRIPTION
Duplicate of upstream PR NovelaNeuro/rec_to_nwb#546.

Fixes bug NovelaNeuro/rec_to_nwb#542 where default header is not applied to fill in missing fields in rec_header GlobalConfiguration.