### PR TITLE
Build NWB file for old dataset, leaving timestamps unresolved

### DIFF
--- a/rec_to_nwb/processing/builder/originators/old_video_files_originator.py
+++ b/rec_to_nwb/processing/builder/originators/old_video_files_originator.py
@@ -11,10 +11,9 @@ class OldVideoFilesOriginator:
         self.old_fl_video_files_manager = OldFlVideoFilesManager(raw_data_path, video_path, video_files_metadata)
 
     def make(self, nwb_content):
-        fl_video_files = self.fl_video_files_manager.get_video_files()
+        fl_video_files = self.old_fl_video_files_manager.get_video_files()
         image_series_list = [
             VideoFilesCreator.create(fl_video_file, self.video_directory, nwb_content)
             for fl_video_file in fl_video_files
         ]
         VideoFilesInjector.inject_all(nwb_content, image_series_list)
-

--- a/rec_to_nwb/processing/builder/raw_to_nwb_builder.py
+++ b/rec_to_nwb/processing/builder/raw_to_nwb_builder.py
@@ -153,23 +153,19 @@ class RawToNWBBuilder:
 
         self.__preprocess_data()
 
+        self.__build_nwb_file(process_mda_valid_time=process_mda_valid_time,
+            process_mda_invalid_time=process_mda_invalid_time,
+            process_pos_valid_time=process_pos_valid_time,
+            process_pos_invalid_time=process_pos_invalid_time)
+
+    def __build_nwb_file(self, process_mda_valid_time=True, process_mda_invalid_time=True,
+               process_pos_valid_time=True, process_pos_invalid_time=True):
+        logger.info('Building NWB files')
         os.makedirs(self.output_path, exist_ok=True)
         os.makedirs(self.video_path, exist_ok=True)
         for date in self.dates:
-            nwb_builder = NWBFileBuilder(
-                data_path=self.data_path,
-                animal_name=self.animal_name,
-                date=date,
-                nwb_metadata=self.nwb_metadata,
-                output_file=self.output_path + self.animal_name + date + ".nwb",
-                process_mda=self.extract_mda,
-                process_dio=self.extract_dio,
-                process_analog=self.extract_analog,
-                preprocessing_path=self.preprocessing_path,
-                video_path=self.video_path,
-                reconfig_header=self.__get_header_path()
-                #reconfig_header=self.__is_rec_config_valid()
-            )
+            logger.info('Date: {}'.format(date))
+            nwb_builder = self.get_nwb_builder(date)
             content = nwb_builder.build()
             nwb_builder.write(content)
             self.append_to_nwb(
@@ -179,6 +175,22 @@ class RawToNWBBuilder:
                 process_pos_valid_time=process_pos_valid_time,
                 process_pos_invalid_time=process_pos_invalid_time
             )
+
+    def get_nwb_builder(self, date):
+        return NWBFileBuilder(
+            data_path=self.data_path,
+            animal_name=self.animal_name,
+            date=date,
+            nwb_metadata=self.nwb_metadata,
+            output_file=self.output_path + self.animal_name + date + ".nwb",
+            process_mda=self.extract_mda,
+            process_dio=self.extract_dio,
+            process_analog=self.extract_analog,
+            preprocessing_path=self.preprocessing_path,
+            video_path=self.video_path,
+            reconfig_header=self.__get_header_path()
+            #reconfig_header=self.__is_rec_config_valid()
+        )
 
     def __preprocess_data(self):
         """process data with rec_to_binaries library"""
@@ -253,4 +265,3 @@ class RawToNWBBuilder:
         preprocessing = self.preprocessing_path + '/' + self.animal_name + '/preprocessing'
         if os.path.exists(preprocessing):
             shutil.rmtree(preprocessing)
-

--- a/rec_to_nwb/processing/builder/raw_to_nwb_builder.py
+++ b/rec_to_nwb/processing/builder/raw_to_nwb_builder.py
@@ -1,6 +1,7 @@
 import logging.config
 import os
 import shutil
+import datetime
 
 from rec_to_binaries import extract_trodes_rec_file
 
@@ -9,6 +10,7 @@ from rec_to_nwb.processing.metadata.metadata_manager import MetadataManager
 from rec_to_nwb.processing.builder.nwb_file_builder import NWBFileBuilder
 from rec_to_nwb.processing.tools.beartype.beartype import beartype
 from rec_to_nwb.processing.validation.not_empty_validator import NotEmptyValidator
+from rec_to_nwb.processing.builder.old_nwb_file_builder import OldNWBFileBuilder
 from rec_to_nwb.processing.validation.validation_registrator import ValidationRegistrator
 
 path = os.path.dirname(os.path.abspath(__file__))
@@ -28,6 +30,9 @@ _DEFAULT_SPIKE_EXPORT_ARGS = ()
 _DEFAULT_TIME_EXPORT_ARGS = ()
 
 _DEFAULT_TRODES_REC_EXPORT_ARGS = ()
+
+# for OldNWBFileBuilder
+_DEFAULT_SESSION_START_TIME = datetime.datetime.fromtimestamp(0) # dummy value for now
 
 
 class RawToNWBBuilder:
@@ -175,12 +180,47 @@ class RawToNWBBuilder:
                 process_pos_valid_time=process_pos_valid_time,
                 process_pos_invalid_time=process_pos_invalid_time
             )
+            
+    def __build_old_nwb_file(self, process_mda_valid_time=True, process_mda_invalid_time=True,
+               process_pos_valid_time=True, process_pos_invalid_time=True):
+        logger.info('Building NWB files ** for old dataset **')
+        os.makedirs(self.output_path, exist_ok=True)
+        os.makedirs(self.video_path, exist_ok=True)
+        for date in self.dates:
+            logger.info('Date: {}'.format(date))
+            nwb_builder = self.get_old_nwb_builder(date)
+            content = nwb_builder.build()
+            nwb_builder.write(content)
+            self.append_to_nwb(
+                nwb_builder=nwb_builder,
+                process_mda_valid_time=process_mda_valid_time,
+                process_mda_invalid_time=process_mda_invalid_time,
+                process_pos_valid_time=process_pos_valid_time,
+                process_pos_invalid_time=process_pos_invalid_time
+            )
 
     def get_nwb_builder(self, date):
         return NWBFileBuilder(
             data_path=self.data_path,
             animal_name=self.animal_name,
             date=date,
+            nwb_metadata=self.nwb_metadata,
+            output_file=self.output_path + self.animal_name + date + ".nwb",
+            process_mda=self.extract_mda,
+            process_dio=self.extract_dio,
+            process_analog=self.extract_analog,
+            preprocessing_path=self.preprocessing_path,
+            video_path=self.video_path,
+            reconfig_header=self.__get_header_path()
+            #reconfig_header=self.__is_rec_config_valid()
+        )
+        
+    def get_old_nwb_builder(self, date):
+        return OldNWBFileBuilder(
+            data_path=self.data_path,
+            animal_name=self.animal_name,
+            date=date,
+            session_start_time=_DEFAULT_SESSION_START_TIME,
             nwb_metadata=self.nwb_metadata,
             output_file=self.output_path + self.animal_name + date + ".nwb",
             process_mda=self.extract_mda,

--- a/rec_to_nwb/processing/builder/raw_to_nwb_builder.py
+++ b/rec_to_nwb/processing/builder/raw_to_nwb_builder.py
@@ -141,6 +141,19 @@ class RawToNWBBuilder:
                 xml_file_path = self.trodes_rec_export_args[counter + 1]
         return xml_file_path
 
+    def __is_old_dataset(self):
+        # check raw directory for the single (first) date
+        all_files = os.listdir(self.data_path + "/" 
+                                + self.animal_name + "/raw/" 
+                                + self.dates[0] + "/")
+        if any([('videoTimeStamps.cameraHWSync' in file) for file in all_files]):
+            # has cameraHWSync files; new dataset
+            return False
+        if any([('videoTimeStamps.cameraHWFrameCount' in file) for file in all_files]):
+            # has cameraHWFrameCount files instead; old dataset
+            return True
+        raise FileNotFoundError('need either cameraHWSync or cameraHWFrameCount files.')
+
     def build_nwb(self, process_mda_valid_time=True, process_mda_invalid_time=True,
                   process_pos_valid_time=True, process_pos_invalid_time=True):
         """Builds nwb file for experiments from given dates.
@@ -157,6 +170,13 @@ class RawToNWBBuilder:
         """
 
         self.__preprocess_data()
+
+        if self.__is_old_dataset():
+            self.__build_old_nwb_file(process_mda_valid_time=process_mda_valid_time,
+                process_mda_invalid_time=process_mda_invalid_time,
+                process_pos_valid_time=process_pos_valid_time,
+                process_pos_invalid_time=process_pos_invalid_time)
+            return
 
         self.__build_nwb_file(process_mda_valid_time=process_mda_valid_time,
             process_mda_invalid_time=process_mda_invalid_time,

--- a/rec_to_nwb/processing/builder/raw_to_nwb_builder.py
+++ b/rec_to_nwb/processing/builder/raw_to_nwb_builder.py
@@ -1,7 +1,8 @@
 import logging.config
 import os
 import shutil
-import datetime
+from datetime import datetime
+import pytz
 
 from rec_to_binaries import extract_trodes_rec_file
 
@@ -32,7 +33,7 @@ _DEFAULT_TIME_EXPORT_ARGS = ()
 _DEFAULT_TRODES_REC_EXPORT_ARGS = ()
 
 # for OldNWBFileBuilder
-_DEFAULT_SESSION_START_TIME = datetime.datetime.fromtimestamp(0) # dummy value for now
+_DEFAULT_SESSION_START_TIME = datetime.fromtimestamp(0, pytz.utc) # dummy value for now
 
 
 class RawToNWBBuilder:

--- a/rec_to_nwb/processing/builder/raw_to_nwb_builder.py
+++ b/rec_to_nwb/processing/builder/raw_to_nwb_builder.py
@@ -212,13 +212,14 @@ class RawToNWBBuilder:
             nwb_builder = self.get_old_nwb_builder(date)
             content = nwb_builder.build()
             nwb_builder.write(content)
-            self.append_to_nwb(
-                nwb_builder=nwb_builder,
-                process_mda_valid_time=process_mda_valid_time,
-                process_mda_invalid_time=process_mda_invalid_time,
-                process_pos_valid_time=process_pos_valid_time,
-                process_pos_invalid_time=process_pos_invalid_time
-            )
+            # self.append_to_nwb(
+            #     nwb_builder=nwb_builder,
+            #     process_mda_valid_time=process_mda_valid_time,
+            #     process_mda_invalid_time=process_mda_invalid_time,
+            #     process_pos_valid_time=process_pos_valid_time,
+            #     process_pos_invalid_time=process_pos_invalid_time
+            # )
+            logger.info('(no timestamps - skipping append_to_nwb)')
 
     def get_nwb_builder(self, date):
         return NWBFileBuilder(

--- a/rec_to_nwb/processing/nwb/common/data_manager.py
+++ b/rec_to_nwb/processing/nwb/common/data_manager.py
@@ -9,7 +9,8 @@ class DataManager(abc.ABC):
 
         self.number_of_datasets = self.get_number_of_datasets()
         self.number_of_files_per_dataset = self.get_number_of_files_per_dataset()
-        self.number_of_rows_per_file = self._get_data_shape(0)[0]
+        # self.number_of_rows_per_file = self._get_data_shape(0)[0]
+        self.number_of_rows_per_file = self._get_number_of_rows_per_file()
         self.file_lenghts_in_datasets = self._get_file_length(self.number_of_datasets)
 
     @abc.abstractmethod
@@ -31,10 +32,17 @@ class DataManager(abc.ABC):
         return np.shape(self.directories)[0]
 
     def get_final_data_shape(self):
-        return self.number_of_rows_per_file * self.number_of_files_per_dataset, sum(self.file_lenghts_in_datasets)
+        # return self.number_of_rows_per_file * self.number_of_files_per_dataset, sum(self.file_lenghts_in_datasets)
+        return (sum(self.number_of_rows_per_file), sum(self.file_lenghts_in_datasets))
 
     def get_directories(self):
         return self.directories
+
+    def _get_number_of_rows_per_file(self):
+        dataset_num = 0   # assume that all datasets have identical structures
+        # but files may have different numbers of rows
+        return [np.shape(self.read_data(dataset_num, file_num))[0]
+            for file_num in range(self.number_of_files_per_dataset)]
 
     def get_number_of_rows_per_file(self):
         return self.number_of_rows_per_file

--- a/rec_to_nwb/processing/nwb/common/old_timestamps_manager.py
+++ b/rec_to_nwb/processing/nwb/common/old_timestamps_manager.py
@@ -21,6 +21,14 @@ class OldTimestampManager(abc.ABC):
     def _get_timestamps(self, dataset_id):
         pass
 
+    def retrieve_real_timestamps(self, dataset_id):
+        timestamps_ids = self.read_timestamps_ids(dataset_id)
+        converted_timestamps = np.ndarray(shape=[len(timestamps_ids), ], dtype="float64")
+        for i, _ in enumerate(timestamps_ids):
+            value = float('nan')  # just a dummy value for now
+            converted_timestamps[i] = value
+        return converted_timestamps
+
     def read_timestamps_ids(self, dataset_id):
         return self._get_timestamps(dataset_id)
 

--- a/rec_to_nwb/processing/nwb/components/analog/old_fl_analog_extractor.py
+++ b/rec_to_nwb/processing/nwb/components/analog/old_fl_analog_extractor.py
@@ -14,7 +14,12 @@ class OldFlAnalogExtractor:
     def extract_analog_for_single_dataset(analog_files):
         single_dataset_data = {}
         for analog_file in analog_files:
-            analog_data = readTrodesExtractedDataFile(analog_files[analog_file])
-            values = analog_data['data']
-            single_dataset_data[analog_data['id']] = values
+            if not 'timestamps' in analog_file:
+                analog_data = readTrodesExtractedDataFile(analog_files[analog_file])
+                values = analog_data['data']
+                single_dataset_data[analog_data['id']] = values
+            else:
+                analog_data = readTrodesExtractedDataFile(analog_files[analog_file])
+                timestamps = analog_data['data']
+                single_dataset_data[analog_file] = timestamps  # not converted
         return single_dataset_data

--- a/rec_to_nwb/processing/nwb/components/device/header/fl_header_device.py
+++ b/rec_to_nwb/processing/nwb/components/device/header/fl_header_device.py
@@ -2,5 +2,8 @@ class FlHeaderDevice:
 
     def __init__(self, name, global_configuration_dict):
         self.name = name
+        for parameter in global_configuration_dict:
+            if global_configuration_dict[parameter] is None:
+                global_configuration_dict[parameter] = ''
         self.global_configuration = global_configuration_dict
 

--- a/rec_to_nwb/processing/nwb/components/electrodes/extension/fl_electrode_extension_factory.py
+++ b/rec_to_nwb/processing/nwb/components/electrodes/extension/fl_electrode_extension_factory.py
@@ -74,7 +74,7 @@ class FlElectrodeExtensionFactory:
     def create_ref_elect_id(cls, spike_n_trodes: list, ntrode_metadata: dict):
         ref_elect_id = []
         for spike_n_trode in spike_n_trodes:
-            if not int(spike_n_trode.ref_n_trode_id) == 0:
+            if spike_n_trode.ref_n_trode_id:
                 for ntrode in ntrode_metadata:
                     if int(ntrode["ntrode_id"]) == int(spike_n_trode.ref_n_trode_id):
                         ref_elect_id.extend(

--- a/rec_to_nwb/processing/nwb/components/iterator/data_iterator.py
+++ b/rec_to_nwb/processing/nwb/components/iterator/data_iterator.py
@@ -20,17 +20,33 @@ class DataIterator(AbstractDataChunkIterator):
         return self
 
     def _get_selection(self):
+        if isinstance(self.number_of_rows, int):
+            # single number (legacy behavior)
+            start_index = (self.current_file * self.number_of_rows)
+            stop_index = ((self.current_file + 1) * self.number_of_rows)
+        else:
+            # expecting a list (different number_of_rows for each file)
+            start_index = sum(self.number_of_rows[0:self.current_file])
+            stop_index = sum(self.number_of_rows[0:(self.current_file + 1)])
         return np.s_[sum(self.dataset_file_length[0:self.current_dataset]):
                      sum(self.dataset_file_length[0:self.current_dataset + 1]),
-               (self.current_file * self.number_of_rows):
-               ((self.current_file + 1) * self.number_of_rows)]
+               start_index:
+               stop_index]
 
     @staticmethod
     def get_selection(number_of_threads, current_dataset, dataset_file_length, current_file, number_of_rows):
+        if isinstance(number_of_rows, int):
+            # single number (legacy behavior)
+            start_index = (current_file * number_of_rows)
+            stop_index = ((current_file + number_of_threads) * number_of_rows)
+        else:
+            # expecting a list (different number_of_rows for each file)
+            start_index = sum(number_of_rows[0:current_file])
+            stop_index = sum(number_of_rows[0:(current_file + number_of_threads)])
         return np.s_[sum(dataset_file_length[0:current_dataset]):
                      sum(dataset_file_length[0:current_dataset + 1]),
-               (current_file * number_of_rows):
-               ((current_file + number_of_threads) * number_of_rows)]
+               start_index:
+               stop_index]
 
     def recommended_chunk_shape(self):
         return None

--- a/rec_to_nwb/processing/nwb/components/mda/old_fl_mda_extractor.py
+++ b/rec_to_nwb/processing/nwb/components/mda/old_fl_mda_extractor.py
@@ -15,6 +15,7 @@ class OldFlMdaExtractor:
         mda_data, timestamps, continuous_time = self.__extract_data()
         mda_timestamp_data_manager = MdaTimestampDataManager(
             directories=timestamps,
+            continuous_time_directories=continuous_time
         )
         mda_data_manager = MdaDataManager(mda_data)
         data_iterator = MultiThreadDataIterator(mda_data_manager)

--- a/rec_to_nwb/processing/nwb/components/video_files/old_fl_video_files_extractor.py
+++ b/rec_to_nwb/processing/nwb/components/video_files/old_fl_video_files_extractor.py
@@ -17,7 +17,7 @@ class OldFlVideoFilesExtractor:
         for video_file in video_files:
             new_fl_video_file = {
                 "name": video_file["name"],
-                "timestamps": [],
+                "timestamps": np.array([]),
                 "device": video_file["camera_id"]
             }
             extracted_video_files.append(new_fl_video_file)

--- a/rec_to_nwb/test/e2etests/test_nwbFullGeneration.py
+++ b/rec_to_nwb/test/e2etests/test_nwbFullGeneration.py
@@ -17,15 +17,15 @@ class TestNwbFullGeneration(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.metadata = MetadataManager(
-            str(path) + '/processing/res/metadata.yml',
-            [str(path) + '/processing/res/probe1.yml',
-             str(path) + '/processing/res/probe2.yml',
-             str(path) + '/processing/res/probe3.yml'])
+            'C:/Users/wmery/PycharmProjects/rec_to_nwb/rec_to_nwb/test/test_data/KF2/raw/20170120/kibbles20170216_metadata.yml',
+            ['C:/Users/wmery/PycharmProjects/rec_to_nwb/rec_to_nwb/test/test_data/KF2/raw/20170120/64c-3s6mm6cm-20um-40um-sl.yml',
+             'C:/Users/wmery/PycharmProjects/rec_to_nwb/rec_to_nwb/test/test_data/KF2/raw/20170120/64c-4s6mm6cm-20um-40um-dl.yml'
+             ])
 
         cls.nwb_builder = NWBFileBuilder(
             data_path=str(path) + '/test_data/',
-            animal_name='beans',
-            date='20190718',
+            animal_name='KF2',
+            date='20170120',
             nwb_metadata=cls.metadata,
             process_dio=True,
             process_mda=True,
@@ -34,19 +34,19 @@ class TestNwbFullGeneration(unittest.TestCase):
             video_path=str(path) + '/test_data'
         )
 
-    @unittest.skip("NWB file creation")
+    #@unittest.skip("NWB file creation")
     def test_nwb_file_builder_generate_nwb(self):
         content = self.nwb_builder.build()
         self.nwb_builder.write(content)
         self.nwb_builder.build_and_append_to_nwb(
-            process_mda_valid_time=True,
-            process_mda_invalid_time=True,
-            process_pos_valid_time=True,
-            process_pos_invalid_time=True
+            process_mda_valid_time=False,
+            process_mda_invalid_time=False,
+            process_pos_valid_time=False,
+            process_pos_invalid_time=False
         )
         self.assertIsNotNone(self.nwb_builder)
 
-    @unittest.skip("read created NWB")
+    #@unittest.skip("read created NWB")
     def test_nwb_file_builder_read_nwb(self):
         with NWBHDF5IO(self.nwb_builder.output_file, 'r') as nwb_file:
             content = nwb_file.read()
@@ -76,8 +76,8 @@ class TestNwbFullGeneration(unittest.TestCase):
             process_analog=True
         )
 
-    @classmethod
-    def tearDownClass(cls):
-        del cls.nwb_builder
-        if os.path.isfile('output.nwb'):
-            os.remove('output.nwb')
+    # @classmethod
+    # def tearDownClass(cls):
+    #     del cls.nwb_builder
+    #     if os.path.isfile('output.nwb'):
+    #         os.remove('output.nwb')

--- a/rec_to_nwb/test/e2etests/test_rawToNwbGeneration.py
+++ b/rec_to_nwb/test/e2etests/test_rawToNwbGeneration.py
@@ -8,25 +8,23 @@ from rec_to_nwb.processing.metadata.metadata_manager import MetadataManager
 
 path = os.path.dirname(os.path.abspath(__file__))
 
-_DEFAULT_TRODES_REC_EXPORT_ARGS = ('-reconfig', str(path) + '/../processing/res/reconfig_header.xml')
+_DEFAULT_TRODES_REC_EXPORT_ARGS = ('-reconfig', 'C:/Users/wmery/PycharmProjects/rec_to_nwb/rec_to_nwb/test/test_data/KF2/raw/20170120/kf2_reconfig.xml')
 
 
-@unittest.skip("Super heavy RAW to NWB Generation")
+#@unittest.skip("Super heavy RAW to NWB Generation")
 class TestRawToNWBGeneration(unittest.TestCase):
 
     def setUp(self):
         self.metadata = MetadataManager(
-            str(path) + '/../processing/res/metadata.yml',
+            'C:/Users/wmery/PycharmProjects/rec_to_nwb/rec_to_nwb/test/test_data/KF2/raw/20170120/kibbles20170216_metadata.yml',
             [
-                str(path) + '/../processing/res/probe1.yml',
-                str(path) + '/../processing/res/probe2.yml',
-                str(path) + '/../processing/res/probe3.yml'
-            ]
-        )
+                'C:/Users/wmery/PycharmProjects/rec_to_nwb/rec_to_nwb/test/test_data/KF2/raw/20170120/64c-3s6mm6cm-20um-40um-sl.yml',
+                'C:/Users/wmery/PycharmProjects/rec_to_nwb/rec_to_nwb/test/test_data/KF2/raw/20170120/64c-4s6mm6cm-20um-40um-dl.yml'
+                ])
         self.builder = RawToNWBBuilder(
-            animal_name='beans',
+            animal_name='KF2',
             data_path=str(path) + '/../test_data/',
-            dates=['20190718'],
+            dates=['20170120'],
             nwb_metadata=self.metadata,
             output_path='',
             video_path=str(path) + '/../test_data',
@@ -41,10 +39,10 @@ class TestRawToNWBGeneration(unittest.TestCase):
 
     def test_from_raw_to_nwb_generation(self):
         self.builder.build_nwb(
-            process_mda_valid_time=True,
-            process_mda_invalid_time=True,
-            process_pos_valid_time=True,
-            process_pos_invalid_time=True
+            process_mda_valid_time=False,
+            process_mda_invalid_time=False,
+            process_pos_valid_time=False,
+            process_pos_invalid_time=False
         )
         self.assertTrue(os.path.exists('beans20190718.nwb'), 'NWBFile did not build')
 
@@ -75,5 +73,5 @@ class TestRawToNWBGeneration(unittest.TestCase):
             trodes_rec_export_args=_DEFAULT_TRODES_REC_EXPORT_ARGS
         )
 
-    def tearDown(self):
-        self.builder.cleanup()
+    # def tearDown(self):
+    #     self.builder.cleanup()


### PR DESCRIPTION
Various code fixes for handling old datasets (e.g., KF2).

Working on top of the upstream branch [user/wmerynda/Try_to_process_kf2](https://github.com/NovelaNeuro/rec_to_nwb/tree/user/wmerynda/Try_to_process_kf2), after merging it into our local master branch.

## Changes:

- Read in camera sample frame counts from cameraHWFrameCount files, instead of cameraHWSync files as in the new datasets (which fixes #4 ), while leaving timestamps unresolved.
    - NOTE: for now, timestamps are either left as an empty array or filled with dummy values. Need attention in future updates.
- User interface won't change: RawToNWBBuider auto-detects whether a given dataset is in an "old" format, by checking whether it contains cameraHWSync or cameraHWFrameCount files. If determined to be an old dataset, it calls OldNWBFileBuilder instead of NWBFileBuilder.
- Also fix DataManager and DataIterator to enable handling of datasets with mixed electrodes (this fixes #5 ).


## Current state:

- At this point, `OldNWBFileBuilder.build()` and `.write()` works successfully for KF2.
- Also works for beans (new dataset) - just a check that this does not break the existing pipeline.
- But `RawToNWBBuilder.append_to_nwb()` fails; IndexError in `process_pos_invalid_time` step. Presumably related to one of the dummy timestamps.
    - Update: the valid/invalid time intervals are determined based on the timestamps. We can skip append_to_nwb() for the old datasets for now.
