### PR TITLE
Fix blank spaces in yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Important note: right now the code assumes that the electrode groups listed belo
 
    ```
     # general information about the experiment 
-    experimenter name: Alison Comrie
+    experimenter_name: Alison Comrie
     lab: Loren Frank
     institution: University of California, San Francisco
     experiment description: Reinforcement learning

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Important note: right now the code assumes that the electrode groups listed belo
     experimenter_name: Alison Comrie
     lab: Loren Frank
     institution: University of California, San Francisco
-    experiment description: Reinforcement learning
+    experiment_description: Reinforcement learning
     session description: Reinforcement leaarning
     session_id: beans_01
     subject:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Important note: right now the code assumes that the electrode groups listed belo
       genotype: Wild Type
       sex: Male
       species: Rat
-      subject id: Beans
+      subject_id: Beans
       weight: Unknown
    #Units of analog and behavioral_events
    units:

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Important note: right now the code assumes that the electrode groups listed belo
       name:
         - Trodes
     # Electrode Groups list used in experiment. Each Id has to be unique, device_type has to refer to existing device_type in probe.yml. Target_x,y,z fields describe the specified location where this group should be. Possible value of units: 'um' or 'mm'
-    electrode groups:
+    electrode_groups:
       - id: 0
         location: mPFC
         device_type: 128c-4s8mm6cm-20um-40um-sl

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Important note: right now the code assumes that the electrode groups listed belo
 
 
    ```
-    # general information about the experiment 
+    # general information about the experiment
     experimenter_name: Alison Comrie
     lab: Loren Frank
     institution: University of California, San Francisco
@@ -74,8 +74,8 @@ Important note: right now the code assumes that the electrode groups listed belo
    units:
       analog: 'unspecified'
       behavioral_events: 'unspecified'  
-   #data acq device used in experiment   
-   data acq device:
+   #data_acq_device used in experiment   
+   data_acq_device:
       - name: acq_0
         system: sample_system
         amplifier: sample_amplifier
@@ -125,14 +125,14 @@ Important note: right now the code assumes that the electrode groups listed belo
         to avoid creating invalid times in case of only small deviations. (optional parameter, default 1.5)
        times_period_multiplier: 1.5      
     # Din/Dout events which filter out files from DIO data in data directory. Each name has to be unique. Stored in behavioral_events section in output nwb file.
-    behavioral_events: 
+    behavioral_events:
       - name: Poke2
         description: Din2
     # Device name. Stored in output nwb file.
-    device: 
+    device:
       name:
         - Trodes
-    # Electrode Groups list used in experiment. Each Id has to be unique, device_type has to refer to existing device_type in probe.yml. Target_x,y,z fields describe the specified location where this group should be. Possible value of units: 'um' or 'mm' 
+    # Electrode Groups list used in experiment. Each Id has to be unique, device_type has to refer to existing device_type in probe.yml. Target_x,y,z fields describe the specified location where this group should be. Possible value of units: 'um' or 'mm'
     electrode groups:
       - id: 0
         location: mPFC
@@ -155,8 +155,8 @@ Important note: right now the code assumes that the electrode groups listed belo
     # Ntrodes list which refer 1:1 to <SpikeNTrode> elements from xml header existing in rec binary file.
     # ntrode_id has to match to SpikeNTrode id, electrode_group_id refers to electrode group,
     # bad_channels is a list of broken channels in the map, where map corresponds to the electrode channels
-      - ntrode_id: 1 
-        electrode_group_id: 0 
+      - ntrode_id: 1
+        electrode_group_id: 0
         bad_channels: [0,2]
         map:  
           0: 0
@@ -230,9 +230,9 @@ If you don't want mda or pos invalid/valid times in your nwb, set accordingly fl
       **dates** = `list of strings` names of folders that contain experiment data <br>
 
       **nwb_metadata** = `MetadataManager` object with metadata.yml and probes.yml <br>
-      
+
       **output_path** = `string` path specifying location and name of result file (dafault 'output.nwb') <br>
-      
+
       **video_path** = `string` path specifying location of video files .h264 where those are copied <b4>
 
       **extract_analog** = `boolean` flag specifying if analog data should be extracted from raw (default True) <br>
@@ -246,22 +246,22 @@ If you don't want mda or pos invalid/valid times in your nwb, set accordingly fl
       **extract_mda** = `boolean` flag specifying if mda data should be extracted from raw (default True) <br>
 
       **parallel_instances** = `int` number of threads, optimal value highly depends on hardware (default 4) <br>
-      
+
       **overwrite** = `boolean`  If true, will overwrite existing files. (default True) <br>
-      
+
       **trodes_rec_export_args** = `tuple of strings` path to rec header file which overrides all headers existing in rec binary files e.g `_DEFAULT_TRODES_REC_EXPORT_ARGS = ('-reconfig', str(path) + '/test/processing/res/reconfig_header.xml')` <br>  
 
    build_nwb arguments:
 
      **process_mda_valid_time** = 'boolean' True if the mda valid times should be build and append to nwb.
                 Need the mda data inside the nwb. (default True) <br>
-     
+
      **process_mda_invalid_time** = 'boolean' True if the mda invalid times should be build and append to nwb.
                 Need the mda data inside the nwb. (default True) <br>
-     
+
      **process_pos_valid_time** = 'boolean' True if the pos valid times should be build and append to nwb.
                 Need the pos data inside the nwb. (default True) <br>
-     
+
      **process_pos_invalid_time** = 'boolean' True if the pos invalid times should be build and append to nwb.
                 Need the pos data inside the nwb. (default True) <br>
 
@@ -286,34 +286,34 @@ After that, you can add mda or pos invalid/valid data to your NWB, using 'build_
    NWBFileBuilder arguments
 
      **data_path** = `string` path to directory containing all experiments data <br>
-     
+
      **animal_name** = `string` directory name which represents animal subject of experiment <br>
-     
+
      **date** = `string` date of experiment <br>
-     
+
      **nwb_metadata** = `MetadataManager` object contains metadata about experiment <br>
-    
+
      **process_dio** = `boolean` flag if dio data should be processed <br>
-     
+
      **process_mda** = `boolean` flag if mda data should be processed <br>
-     
+
      **process_analog** = `boolean` flag if analog data should be processed <br>
-     
+
      **video_path** = `string` path specifying location of video files .h264 where those are copied <b4>
-     
+
      **output_file** = `string` path and name specifying where .nwb file gonna be written <br>
 
    build_and_append_to_nwb arguments:
 
      **process_mda_valid_time** = 'boolean' True if the mda valid times should be build and append to nwb.
                 Need the mda data inside the nwb. (default True) <br>
-     
+
      **process_mda_invalid_time** = 'boolean' True if the mda invalid times should be build and append to nwb.
                 Need the mda data inside the nwb. (default True) <br>
-     
+
      **process_pos_valid_time** = 'boolean' True if the pos valid times should be build and append to nwb.
                 Need the pos data inside the nwb. (default True) <br>
-     
+
      **process_pos_invalid_time** = 'boolean' True if the pos invalid times should be build and append to nwb.
                 Need the pos data inside the nwb. (default True) <br>
 
@@ -552,4 +552,3 @@ After that, you can add mda or pos invalid/valid data to your NWB, using 'build_
    |-- README.md
    ```
 When processing completes, a nwb file is created in the output_path directory
-

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Important note: right now the code assumes that the electrode groups listed belo
     lab: Loren Frank
     institution: University of California, San Francisco
     experiment_description: Reinforcement learning
-    session description: Reinforcement leaarning
+    session_description: Reinforcement leaarning
     session_id: beans_01
     subject:
       description: Long Evans Rat

--- a/rec_to_nwb/processing/builder/nwb_file_builder.py
+++ b/rec_to_nwb/processing/builder/nwb_file_builder.py
@@ -309,7 +309,7 @@ class NWBFileBuilder:
                 genotype=self.metadata['subject']['genotype'],
                 sex=self.metadata['subject']['sex'],
                 species=self.metadata['subject']['species'],
-                subject_id=self.metadata['subject']['subject id'],
+                subject_id=self.metadata['subject']['subject_id'],
                 weight=str(self.metadata['subject']['weight']),
             ),
         )

--- a/rec_to_nwb/processing/builder/nwb_file_builder.py
+++ b/rec_to_nwb/processing/builder/nwb_file_builder.py
@@ -252,7 +252,7 @@ class NWBFileBuilder:
         self.data_acq_device_originator = DataAcqDeviceOriginator(
             device_factory=self.device_factory,
             device_injector=self.device_injector,
-            metadata=self.metadata['data acq device']
+            metadata=self.metadata['data_acq_device']
         )
 
         if self.process_mda:

--- a/rec_to_nwb/processing/builder/nwb_file_builder.py
+++ b/rec_to_nwb/processing/builder/nwb_file_builder.py
@@ -294,7 +294,7 @@ class NWBFileBuilder:
 
         logger.info('Building components for NWB')
         nwb_content = NWBFile(
-            session_description=self.metadata['session description'],
+            session_description=self.metadata['session_description'],
             experimenter=self.metadata['experimenter_name'],
             lab=self.metadata['lab'],
             institution=self.metadata['institution'],

--- a/rec_to_nwb/processing/builder/nwb_file_builder.py
+++ b/rec_to_nwb/processing/builder/nwb_file_builder.py
@@ -295,7 +295,7 @@ class NWBFileBuilder:
         logger.info('Building components for NWB')
         nwb_content = NWBFile(
             session_description=self.metadata['session description'],
-            experimenter=self.metadata['experimenter name'],
+            experimenter=self.metadata['experimenter_name'],
             lab=self.metadata['lab'],
             institution=self.metadata['institution'],
             session_start_time=self.session_start_time,

--- a/rec_to_nwb/processing/builder/nwb_file_builder.py
+++ b/rec_to_nwb/processing/builder/nwb_file_builder.py
@@ -303,7 +303,7 @@ class NWBFileBuilder:
             identifier=str(uuid.uuid1()),
             session_id=self.metadata['session_id'],
             notes=self.link_to_notes,
-            experiment_description=self.metadata['experiment description'],
+            experiment_description=self.metadata['experiment_description'],
             subject=Subject(
                 description=self.metadata['subject']['description'],
                 genotype=self.metadata['subject']['genotype'],

--- a/rec_to_nwb/processing/builder/originators/electrode_group_originator.py
+++ b/rec_to_nwb/processing/builder/originators/electrode_group_originator.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class ElectrodeGroupOriginator:
 
     def __init__(self, metadata):
-        self.fl_nwb_electrode_group_manager = FlNwbElectrodeGroupManager(metadata['electrode groups'])
+        self.fl_nwb_electrode_group_manager = FlNwbElectrodeGroupManager(metadata['electrode_groups'])
         self.electrode_group_creator = ElectrodeGroupFactory()
         self.electrode_group_injector = ElectrodeGroupInjector()
 

--- a/rec_to_nwb/processing/builder/originators/electrodes_originator.py
+++ b/rec_to_nwb/processing/builder/originators/electrodes_originator.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class ElectrodesOriginator:
 
     def __init__(self, probes, metadata):
-        self.fl_electrode_manager = FlElectrodeManager(probes, metadata['electrode groups'])
+        self.fl_electrode_manager = FlElectrodeManager(probes, metadata['electrode_groups'])
         self.electrode_creator = ElectrodesCreator()
 
     def make(self, nwb_content, electrode_groups, electrodes_valid_map, electrode_groups_valid_map):

--- a/rec_to_nwb/processing/builder/originators/shanks_electrodes_originator.py
+++ b/rec_to_nwb/processing/builder/originators/shanks_electrodes_originator.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class ShanksElectrodeOriginator:
 
     def __init__(self, probes, metadata):
-        self.fl_shanks_electrode_manager = FlShanksElectrodeManager(probes, metadata['electrode groups'])
+        self.fl_shanks_electrode_manager = FlShanksElectrodeManager(probes, metadata['electrode_groups'])
         self.shanks_electrodes_creator = ShanksElectrodeCreator()
 
     def make(self):

--- a/rec_to_nwb/processing/builder/originators/shanks_originator.py
+++ b/rec_to_nwb/processing/builder/originators/shanks_originator.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class ShanksOriginator:
 
     def __init__(self, probes, metadata):
-        self.fl_shank_manager = FlShankManager(probes, metadata['electrode groups'])
+        self.fl_shank_manager = FlShankManager(probes, metadata['electrode_groups'])
         self.shank_creator = ShankCreator()
 
     def make(self, shanks_electrodes_dict):

--- a/rec_to_nwb/processing/metadata/corrupted_data_manager.py
+++ b/rec_to_nwb/processing/metadata/corrupted_data_manager.py
@@ -27,10 +27,10 @@ class CorruptedDataManager:
         """
 
         electrodes_valid_map = self.__get_electrodes_valid_map(
-            ntrode_metadata=self.metadata['ntrode electrode group channel map']
+            ntrode_metadata=self.metadata['ntrode_electrode_group_channel_map']
         )
         electrode_groups_valid_map = self.__get_electrode_groups_valid_map(
-            ntrode_metadata=self.metadata['ntrode electrode group channel map'],
+            ntrode_metadata=self.metadata['ntrode_electrode_group_channel_map'],
             electrodes_valid_map=electrodes_valid_map
         )
         probes_valid_map = self.__get_probes_valid_map(

--- a/rec_to_nwb/processing/metadata/corrupted_data_manager.py
+++ b/rec_to_nwb/processing/metadata/corrupted_data_manager.py
@@ -34,7 +34,7 @@ class CorruptedDataManager:
             electrodes_valid_map=electrodes_valid_map
         )
         probes_valid_map = self.__get_probes_valid_map(
-            electrode_groups_metadata=self.metadata['electrode groups'],
+            electrode_groups_metadata=self.metadata['electrode_groups'],
             electrode_groups_valid_map=electrode_groups_valid_map
         )
 

--- a/rec_to_nwb/processing/metadata/metadata_manager.py
+++ b/rec_to_nwb/processing/metadata/metadata_manager.py
@@ -40,7 +40,7 @@ class MetadataManager:
 
     def __str__(self):
         metadata_info = 'Experimenter: ' + self.metadata['experimenter_name'] + \
-                        '\nDescription: ' + self.metadata['experiment description'] + \
+                        '\nDescription: ' + self.metadata['experiment_description'] + \
                         '\nSession Id: ' + self.metadata['session_id'] + \
                         '\nSubject: ' + self.metadata['subject']['description']
 

--- a/rec_to_nwb/processing/metadata/metadata_manager.py
+++ b/rec_to_nwb/processing/metadata/metadata_manager.py
@@ -39,7 +39,7 @@ class MetadataManager:
         return self.fl_probes_extractor.extract_probes_metadata(probes_paths)
 
     def __str__(self):
-        metadata_info = 'Experimenter: ' + self.metadata['experimenter name'] + \
+        metadata_info = 'Experimenter: ' + self.metadata['experimenter_name'] + \
                         '\nDescription: ' + self.metadata['experiment description'] + \
                         '\nSession Id: ' + self.metadata['session_id'] + \
                         '\nSubject: ' + self.metadata['subject']['description']

--- a/rec_to_nwb/processing/nwb/components/electrodes/extension/fl_electrode_extension_manager.py
+++ b/rec_to_nwb/processing/nwb/components/electrodes/extension/fl_electrode_extension_manager.py
@@ -28,7 +28,7 @@ class FlElectrodeExtensionManager:
     @beartype
     def get_fl_electrodes_extension(self, electrodes_valid_map: list) -> FlElectrodeExtension:
         probes_metadata = self.probes_metadata
-        electrode_groups_metadata = self.metadata['electrode groups']
+        electrode_groups_metadata = self.metadata['electrode_groups']
         ntrode_metadata = self.metadata['ntrode electrode group channel map']
         spike_n_trodes = self.header.configuration.spike_configuration.spike_n_trodes
 

--- a/rec_to_nwb/processing/nwb/components/electrodes/extension/fl_electrode_extension_manager.py
+++ b/rec_to_nwb/processing/nwb/components/electrodes/extension/fl_electrode_extension_manager.py
@@ -29,7 +29,7 @@ class FlElectrodeExtensionManager:
     def get_fl_electrodes_extension(self, electrodes_valid_map: list) -> FlElectrodeExtension:
         probes_metadata = self.probes_metadata
         electrode_groups_metadata = self.metadata['electrode_groups']
-        ntrode_metadata = self.metadata['ntrode electrode group channel map']
+        ntrode_metadata = self.metadata['ntrode_electrode_group_channel_map']
         spike_n_trodes = self.header.configuration.spike_configuration.spike_n_trodes
 
         rel = FlElectrodeExtensionFactory.create_rel(

--- a/rec_to_nwb/processing/validation/metadata_section_validator.py
+++ b/rec_to_nwb/processing/validation/metadata_section_validator.py
@@ -23,8 +23,8 @@ class MetadataSectionValidator:
             raise MissingDataException('metadata is missing subject')
         if 'units' not in self.metadata:
             raise MissingDataException('metadata is missing units')
-        if 'data acq device' not in self.metadata:
-            raise MissingDataException('metadata is missing data acq device')
+        if 'data_acq_device' not in self.metadata:
+            raise MissingDataException('metadata is missing data_acq_device')
         if 'cameras' not in self.metadata:
             raise MissingDataException('metadata is missing cameras')
         if 'tasks' not in self.metadata:

--- a/rec_to_nwb/processing/validation/metadata_section_validator.py
+++ b/rec_to_nwb/processing/validation/metadata_section_validator.py
@@ -39,5 +39,5 @@ class MetadataSectionValidator:
             raise MissingDataException('metadata is missing behavioral_events')
         if 'electrode_groups' not in self.metadata:
             raise MissingDataException('metadata is missing electrode_groups')
-        if 'ntrode electrode group channel map' not in self.metadata:
-            raise MissingDataException('metadata is missing ntrode electrode group channel map')
+        if 'ntrode_electrode_group_channel_map' not in self.metadata:
+            raise MissingDataException('metadata is missing ntrode_electrode_group_channel_map')

--- a/rec_to_nwb/processing/validation/metadata_section_validator.py
+++ b/rec_to_nwb/processing/validation/metadata_section_validator.py
@@ -13,8 +13,8 @@ class MetadataSectionValidator:
             raise MissingDataException('metadata is missing lab')
         if 'institution' not in self.metadata:
             raise MissingDataException('metadata is missing institution')
-        if 'experiment description' not in self.metadata:
-            raise MissingDataException('metadata is missing experiment description')
+        if 'experiment_description' not in self.metadata:
+            raise MissingDataException('metadata is missing experiment_description')
         if 'session description' not in self.metadata:
             raise MissingDataException('metadata is missing session description')
         if 'session_id' not in self.metadata:

--- a/rec_to_nwb/processing/validation/metadata_section_validator.py
+++ b/rec_to_nwb/processing/validation/metadata_section_validator.py
@@ -7,8 +7,8 @@ class MetadataSectionValidator:
         self.metadata = metadata
 
     def validate_sections(self):
-        if 'experimenter name' not in self.metadata:
-            raise MissingDataException('metadata is missing experimenter name')
+        if 'experimenter_name' not in self.metadata:
+            raise MissingDataException('metadata is missing experimenter_name')
         if 'lab' not in self.metadata:
             raise MissingDataException('metadata is missing lab')
         if 'institution' not in self.metadata:

--- a/rec_to_nwb/processing/validation/metadata_section_validator.py
+++ b/rec_to_nwb/processing/validation/metadata_section_validator.py
@@ -15,8 +15,8 @@ class MetadataSectionValidator:
             raise MissingDataException('metadata is missing institution')
         if 'experiment_description' not in self.metadata:
             raise MissingDataException('metadata is missing experiment_description')
-        if 'session description' not in self.metadata:
-            raise MissingDataException('metadata is missing session description')
+        if 'session_description' not in self.metadata:
+            raise MissingDataException('metadata is missing session_description')
         if 'session_id' not in self.metadata:
             raise MissingDataException('metadata is missing session_id')
         if 'subject' not in self.metadata:

--- a/rec_to_nwb/processing/validation/metadata_section_validator.py
+++ b/rec_to_nwb/processing/validation/metadata_section_validator.py
@@ -37,7 +37,7 @@ class MetadataSectionValidator:
             raise MissingDataException('metadata is missing times_period_multiplier')
         if 'behavioral_events' not in self.metadata:
             raise MissingDataException('metadata is missing behavioral_events')
-        if 'electrode groups' not in self.metadata:
-            raise MissingDataException('metadata is missing electrode groups')
+        if 'electrode_groups' not in self.metadata:
+            raise MissingDataException('metadata is missing electrode_groups')
         if 'ntrode electrode group channel map' not in self.metadata:
             raise MissingDataException('metadata is missing ntrode electrode group channel map')

--- a/rec_to_nwb/processing/validation/ntrode_validator.py
+++ b/rec_to_nwb/processing/validation/ntrode_validator.py
@@ -26,7 +26,7 @@ class NTrodeValidator(Validator):
         self.probes_metadata = probes_metadata
 
     def create_summary(self):
-        ntrodes = self.metadata['ntrode electrode group channel map']
+        ntrodes = self.metadata['ntrode_electrode_group_channel_map']
         if len(ntrodes) == 0:
             raise InvalidMetadataException("There are no ntrodes defined in metadata.yml file.")
         if self.header is None or \
@@ -47,7 +47,7 @@ class NTrodeValidator(Validator):
             probe_metadata = filter_probe_by_type(probes_metadata, electrode_group['device_type'])
             electrodes_in_probe = count_electrodes_in_probe(probe_metadata)
             electrodes_in_group = count_electrodes_in_ntrode(
-                metadata['ntrode electrode group channel map'],
+                metadata['ntrode_electrode_group_channel_map'],
                 electrode_group['id']
             )
             if electrodes_in_probe != electrodes_in_group:

--- a/rec_to_nwb/processing/validation/ntrode_validator.py
+++ b/rec_to_nwb/processing/validation/ntrode_validator.py
@@ -43,7 +43,7 @@ class NTrodeValidator(Validator):
 
     @staticmethod
     def validate_ntrode_metadata_with_probe_metadata(metadata, probes_metadata):
-        for electrode_group in metadata['electrode groups']:
+        for electrode_group in metadata['electrode_groups']:
             probe_metadata = filter_probe_by_type(probes_metadata, electrode_group['device_type'])
             electrodes_in_probe = count_electrodes_in_probe(probe_metadata)
             electrodes_in_group = count_electrodes_in_ntrode(

--- a/rec_to_nwb/test/processing/dio/test_dioInjector.py
+++ b/rec_to_nwb/test/processing/dio/test_dioInjector.py
@@ -18,7 +18,7 @@ class TestDioManager(unittest.TestCase):
 
     def setUp(self):
         self.nwb_content = NWBFile(
-            session_description='session description',
+            session_description='session_description',
             experimenter='experimenter_name',
             lab='lab',
             institution='institution',

--- a/rec_to_nwb/test/processing/dio/test_dioInjector.py
+++ b/rec_to_nwb/test/processing/dio/test_dioInjector.py
@@ -24,7 +24,7 @@ class TestDioManager(unittest.TestCase):
             institution='institution',
             session_start_time=start_time,
             identifier='identifier',
-            experiment_description='experiment description')
+            experiment_description='experiment_description')
 
         processing_module = ProcessingModule(name='test_processing_module_name', description='test_description')
         self.nwb_content.add_processing_module(processing_module)

--- a/rec_to_nwb/test/processing/dio/test_dioInjector.py
+++ b/rec_to_nwb/test/processing/dio/test_dioInjector.py
@@ -19,7 +19,7 @@ class TestDioManager(unittest.TestCase):
     def setUp(self):
         self.nwb_content = NWBFile(
             session_description='session description',
-            experimenter='experimenter name',
+            experimenter='experimenter_name',
             lab='lab',
             institution='institution',
             session_start_time=start_time,

--- a/rec_to_nwb/test/processing/electrodes/extension/test_flElectrodeExtensionManager.py
+++ b/rec_to_nwb/test/processing/electrodes/extension/test_flElectrodeExtensionManager.py
@@ -45,7 +45,7 @@ class TestFlElectrodeExtensionManager(TestCase):
              ]}
         ]
         metadata = {
-            'electrode groups': [
+            'electrode_groups': [
                 {'id': '0', 'location': 'mPFC', 'device_type': 'tetrode_12.5', 'description': 'Probe 1'},
                 {'id': '1', 'location': 'mPFC', 'device_type': '128c-4s8mm6cm-20um-40um-sl', 'description': 'Probe 2'}],
 
@@ -110,7 +110,7 @@ class TestFlElectrodeExtensionManager(TestCase):
              ]}
         ]
         metadata = {
-            'electrode groups': [
+            'electrode_groups': [
                 {'id': '0', 'location': 'mPFC', 'device_type': 'tetrode_12.5', 'description': 'Probe 1'},
                 {'id': '1', 'location': 'mPFC', 'device_type': '128c-4s8mm6cm-20um-40um-sl', 'description': 'Probe 2'}],
 

--- a/rec_to_nwb/test/processing/electrodes/extension/test_flElectrodeExtensionManager.py
+++ b/rec_to_nwb/test/processing/electrodes/extension/test_flElectrodeExtensionManager.py
@@ -2,13 +2,14 @@ import os
 from unittest import TestCase
 from unittest.mock import Mock
 
-from testfixtures import should_raise
-
-from rec_to_nwb.processing.exceptions.not_compatible_metadata import NotCompatibleMetadata
+from rec_to_nwb.processing.exceptions.not_compatible_metadata import \
+    NotCompatibleMetadata
 from rec_to_nwb.processing.header.module.header import Header
-from rec_to_nwb.processing.nwb.components.electrodes.extension.fl_electrode_extension import FlElectrodeExtension
+from rec_to_nwb.processing.nwb.components.electrodes.extension.fl_electrode_extension import \
+    FlElectrodeExtension
 from rec_to_nwb.processing.nwb.components.electrodes.extension.fl_electrode_extension_manager import \
     FlElectrodeExtensionManager
+from testfixtures import should_raise
 
 path = os.path.dirname(os.path.abspath(__file__))
 
@@ -46,38 +47,53 @@ class TestFlElectrodeExtensionManager(TestCase):
         ]
         metadata = {
             'electrode_groups': [
-                {'id': '0', 'location': 'mPFC', 'device_type': 'tetrode_12.5', 'description': 'Probe 1'},
+                {'id': '0', 'location': 'mPFC',
+                    'device_type': 'tetrode_12.5', 'description': 'Probe 1'},
                 {'id': '1', 'location': 'mPFC', 'device_type': '128c-4s8mm6cm-20um-40um-sl', 'description': 'Probe 2'}],
 
-            'ntrode electrode group channel map': [
-                {'ntrode_id': '1', 'probe_id': '0', 'bad_channels': ['0', '2'], 'map': {'0': '0', '1': '1', '2': '2'}},
-                {'ntrode_id': '2', 'probe_id': '0', 'bad_channels': ['0'], 'map': {'0': '32', '1': '33', '2': '34'}},
-                {'ntrode_id': '3', 'probe_id': '1', 'bad_channels': ['0', '1'], 'map': {'0': '64', '1': '65', '2': '66'}},
-                {'ntrode_id': '4', 'probe_id': '1', 'bad_channels': ['0', '2'], 'map': {'0': '96', '1': '97', '2': '98'}}
+            'ntrode_electrode_group_channel_map': [
+                {'ntrode_id': '1', 'probe_id': '0', 'bad_channels': [
+                    '0', '2'], 'map': {'0': '0', '1': '1', '2': '2'}},
+                {'ntrode_id': '2', 'probe_id': '0', 'bad_channels': [
+                    '0'], 'map': {'0': '32', '1': '33', '2': '34'}},
+                {'ntrode_id': '3', 'probe_id': '1', 'bad_channels': [
+                    '0', '1'], 'map': {'0': '64', '1': '65', '2': '66'}},
+                {'ntrode_id': '4', 'probe_id': '1', 'bad_channels': [
+                    '0', '2'], 'map': {'0': '96', '1': '97', '2': '98'}}
             ]
         }
-        header = Header(str(path) + '/../../res/electrodes_extensions/header.xml')
-        mock_electrodes_valid_map = [False, True, False, False, True, True, False, False, True, False, True, False]
+        header = Header(
+            str(path) + '/../../res/electrodes_extensions/header.xml')
+        mock_electrodes_valid_map = [
+            False, True, False, False, True, True, False, False, True, False, True, False]
 
         fl_electrode_extension_manager = FlElectrodeExtensionManager(
             probes_metadata=probes_metadata,
             metadata=metadata,
             header=header,
         )
-        fl_electrode_extension = fl_electrode_extension_manager.get_fl_electrodes_extension(mock_electrodes_valid_map)
+        fl_electrode_extension = fl_electrode_extension_manager.get_fl_electrodes_extension(
+            mock_electrodes_valid_map)
 
         self.assertIsInstance(fl_electrode_extension, FlElectrodeExtension)
-        self.assertEqual(fl_electrode_extension.rel_x, [0.0, 0.0, 40.0, 0.0, 0.0])
-        self.assertEqual(fl_electrode_extension.rel_y, [0.0, 0.0, 0.0, 600.0, 900.0])
-        self.assertEqual(fl_electrode_extension.rel_z, [0.0, 0.0, 0.0, 0.0, 0.0])
+        self.assertEqual(fl_electrode_extension.rel_x,
+                         [0.0, 0.0, 40.0, 0.0, 0.0])
+        self.assertEqual(fl_electrode_extension.rel_y,
+                         [0.0, 0.0, 0.0, 600.0, 900.0])
+        self.assertEqual(fl_electrode_extension.rel_z,
+                         [0.0, 0.0, 0.0, 0.0, 0.0])
         self.assertEqual(fl_electrode_extension.hw_chan[0], 85)
         self.assertEqual(fl_electrode_extension.hw_chan[-1], 102)
         self.assertEqual(fl_electrode_extension.ntrode_id, [1, 2, 2, 3, 4])
         self.assertEqual(fl_electrode_extension.channel_id, [1, 1, 2, 2, 1])
-        self.assertEqual(fl_electrode_extension.probe_shank, ['0', '0', '0', '2', '3'])
-        self.assertEqual(fl_electrode_extension.bad_channels, [False, False, False, False, False])
-        self.assertEqual(fl_electrode_extension.probe_electrode, ['1', '0', '1', '64', '96'])
-        self.assertEqual(fl_electrode_extension.ref_elect_id, [-1, 2, 2, 34, 34])
+        self.assertEqual(fl_electrode_extension.probe_shank,
+                         ['0', '0', '0', '2', '3'])
+        self.assertEqual(fl_electrode_extension.bad_channels,
+                         [False, False, False, False, False])
+        self.assertEqual(fl_electrode_extension.probe_electrode, [
+                         '1', '0', '1', '64', '96'])
+        self.assertEqual(fl_electrode_extension.ref_elect_id,
+                         [-1, 2, 2, 34, 34])
 
     @should_raise(NotCompatibleMetadata)
     def test_electrode_extension_manager_failed_due_to_not_equal_extensions_length(self):
@@ -111,17 +127,23 @@ class TestFlElectrodeExtensionManager(TestCase):
         ]
         metadata = {
             'electrode_groups': [
-                {'id': '0', 'location': 'mPFC', 'device_type': 'tetrode_12.5', 'description': 'Probe 1'},
+                {'id': '0', 'location': 'mPFC',
+                    'device_type': 'tetrode_12.5', 'description': 'Probe 1'},
                 {'id': '1', 'location': 'mPFC', 'device_type': '128c-4s8mm6cm-20um-40um-sl', 'description': 'Probe 2'}],
 
-            'ntrode electrode group channel map': [
-                {'ntrode_id': '1', 'probe_id': '0', 'bad_channels': ['0', '2'], 'map': {'0': '0', '1': '1', '2': '2', '3': '3', '4': '4'}},
-                {'ntrode_id': '2', 'probe_id': '0', 'bad_channels': ['0', '3'], 'map': {'0': '32', '1': '33', '2': '34', '3': '35', '4': '36'}},
-                {'ntrode_id': '3', 'probe_id': '1', 'bad_channels': ['0', '1'], 'map': {'0': '64', '1': '65', '2': '66', '3': '67', '4': '68'}},
-                {'ntrode_id': '4', 'probe_id': '1', 'bad_channels': ['0', '2', '3'], 'map': {'0': '96', '1': '97', '2': '98', '3': '99', '4': '100'}}
+            'ntrode_electrode_group_channel_map': [
+                {'ntrode_id': '1', 'probe_id': '0', 'bad_channels': ['0', '2'], 'map': {
+                    '0': '0', '1': '1', '2': '2', '3': '3', '4': '4'}},
+                {'ntrode_id': '2', 'probe_id': '0', 'bad_channels': ['0', '3'], 'map': {
+                    '0': '32', '1': '33', '2': '34', '3': '35', '4': '36'}},
+                {'ntrode_id': '3', 'probe_id': '1', 'bad_channels': ['0', '1'], 'map': {
+                    '0': '64', '1': '65', '2': '66', '3': '67', '4': '68'}},
+                {'ntrode_id': '4', 'probe_id': '1', 'bad_channels': ['0', '2', '3'], 'map': {
+                    '0': '96', '1': '97', '2': '98', '3': '99', '4': '100'}}
             ]
         }
-        header = Header(str(path) + '/../../res/nwb_elements_builder_test/header.xml')
+        header = Header(
+            str(path) + '/../../res/nwb_elements_builder_test/header.xml')
         mock_electrodes_valid_map = [
             True, False, True, False,
             False, True, False, False,
@@ -135,7 +157,8 @@ class TestFlElectrodeExtensionManager(TestCase):
             metadata=metadata,
             header=header,
         )
-        fl_electrode_extension_manager.get_fl_electrodes_extension(mock_electrodes_valid_map)
+        fl_electrode_extension_manager.get_fl_electrodes_extension(
+            mock_electrodes_valid_map)
 
     @should_raise(TypeError)
     def test_electrode_extension_manager_failed_due_to_None_param(self):

--- a/rec_to_nwb/test/processing/metadata/test_corruptedDataManager.py
+++ b/rec_to_nwb/test/processing/metadata/test_corruptedDataManager.py
@@ -10,7 +10,7 @@ class TestCorruptedDataManager(TestCase):
 
     def test_corrupted_data_manager_get_valid_map_dict_successfully(self):
         metadata = {
-            'ntrode electrode group channel map': [
+            'ntrode_electrode_group_channel_map': [
                 {'ntrode_id': 1, 'electrode_group_id': 0, 'bad_channels': [1],
                  'map': {0: 0, 1: 1}},
                 {'ntrode_id': 2, 'electrode_group_id': 0, 'bad_channels': [1],
@@ -79,7 +79,7 @@ class TestCorruptedDataManager(TestCase):
     @should_raise(CorruptedDataException)
     def test_corrupted_data_manager_get_valid_map_dict_end_nbw_building_process_due_to_lack_of_good_data(self):
         metadata = {
-            'ntrode electrode group channel map': [
+            'ntrode_electrode_group_channel_map': [
                 {'ntrode_id': 1, 'electrode_group_id': 0, 'bad_channels': [0, 1], 'map': {0: 0, 1: 1}},
                 {'ntrode_id': 2, 'electrode_group_id': 1, 'bad_channels': [0, 1], 'map': {0: 2, 1: 3}},
             ],

--- a/rec_to_nwb/test/processing/metadata/test_corruptedDataManager.py
+++ b/rec_to_nwb/test/processing/metadata/test_corruptedDataManager.py
@@ -28,7 +28,7 @@ class TestCorruptedDataManager(TestCase):
                 {'ntrode_id': 8, 'electrode_group_id': 3, 'bad_channels': [0, 1],
                  'map': {0: 14, 1: 15}}
             ],
-            'electrode groups': [
+            'electrode_groups': [
                 {'id': 0, 'location': 'mPFC', 'device_type': 'tetrode_12.5',
                  'description': 'Probe 1'},
                 {'id': 1, 'location': 'mPFC', 'device_type': '128c-4s8mm6cm-20um-40um-sl',
@@ -83,7 +83,7 @@ class TestCorruptedDataManager(TestCase):
                 {'ntrode_id': 1, 'electrode_group_id': 0, 'bad_channels': [0, 1], 'map': {0: 0, 1: 1}},
                 {'ntrode_id': 2, 'electrode_group_id': 1, 'bad_channels': [0, 1], 'map': {0: 2, 1: 3}},
             ],
-            'electrode groups': [
+            'electrode_groups': [
                 {'id': 0, 'location': 'mPFC', 'device_type': 'tetrode_12.5',
                  'description': 'Probe 1'},
                 {'id': 1, 'location': 'mPFC', 'device_type': '128c-4s8mm6cm-20um-40um-sl',

--- a/rec_to_nwb/test/processing/metadata/test_metadataManager.py
+++ b/rec_to_nwb/test/processing/metadata/test_metadataManager.py
@@ -21,7 +21,7 @@ class TestMetadataManager(TestCase):
         )
 
         metadata_fields = nwb_metadata.metadata.keys()
-        self.assertIn('experimenter name', metadata_fields)
+        self.assertIn('experimenter_name', metadata_fields)
         self.assertIn('lab', metadata_fields)
         self.assertIn('institution', metadata_fields)
         self.assertIn('session_id', metadata_fields)

--- a/rec_to_nwb/test/processing/metadata/test_metadataManager.py
+++ b/rec_to_nwb/test/processing/metadata/test_metadataManager.py
@@ -25,7 +25,7 @@ class TestMetadataManager(TestCase):
         self.assertIn('lab', metadata_fields)
         self.assertIn('institution', metadata_fields)
         self.assertIn('session_id', metadata_fields)
-        self.assertIn('experiment description', metadata_fields)
+        self.assertIn('experiment_description', metadata_fields)
         self.assertIn('session description', metadata_fields)
         self.assertIn('subject', metadata_fields)
         self.assertIn('tasks', metadata_fields)

--- a/rec_to_nwb/test/processing/metadata/test_metadataManager.py
+++ b/rec_to_nwb/test/processing/metadata/test_metadataManager.py
@@ -42,7 +42,7 @@ class TestMetadataManager(TestCase):
         self.assertIn('genotype', subject_fields)
         self.assertIn('sex', subject_fields)
         self.assertIn('species', subject_fields)
-        self.assertIn('subject id', subject_fields)
+        self.assertIn('subject_id', subject_fields)
         self.assertIn('weight', subject_fields)
 
         tasks_fields = nwb_metadata.metadata['tasks'][0].keys()

--- a/rec_to_nwb/test/processing/metadata/test_metadataManager.py
+++ b/rec_to_nwb/test/processing/metadata/test_metadataManager.py
@@ -30,7 +30,7 @@ class TestMetadataManager(TestCase):
         self.assertIn('subject', metadata_fields)
         self.assertIn('tasks', metadata_fields)
         self.assertIn('behavioral_events', metadata_fields)
-        self.assertIn('electrode groups', metadata_fields)
+        self.assertIn('electrode_groups', metadata_fields)
         self.assertIn('ntrode electrode group channel map', metadata_fields)
 
         self.assertIn('units', metadata_fields)
@@ -53,7 +53,7 @@ class TestMetadataManager(TestCase):
         self.assertIn('description', behavioral_event_fields)
         self.assertIn('name', behavioral_event_fields)
 
-        electrode_groups_fields = nwb_metadata.metadata['electrode groups'][0].keys()
+        electrode_groups_fields = nwb_metadata.metadata['electrode_groups'][0].keys()
         self.assertIn('id', electrode_groups_fields)
         self.assertIn('location', electrode_groups_fields)
         self.assertIn('device_type', electrode_groups_fields)

--- a/rec_to_nwb/test/processing/metadata/test_metadataManager.py
+++ b/rec_to_nwb/test/processing/metadata/test_metadataManager.py
@@ -31,7 +31,7 @@ class TestMetadataManager(TestCase):
         self.assertIn('tasks', metadata_fields)
         self.assertIn('behavioral_events', metadata_fields)
         self.assertIn('electrode_groups', metadata_fields)
-        self.assertIn('ntrode electrode group channel map', metadata_fields)
+        self.assertIn('ntrode_electrode_group_channel_map', metadata_fields)
 
         self.assertIn('units', metadata_fields)
         self.assertIn('unspecified', nwb_metadata.metadata['units']['analog'])
@@ -59,7 +59,7 @@ class TestMetadataManager(TestCase):
         self.assertIn('device_type', electrode_groups_fields)
         self.assertIn('description', electrode_groups_fields)
 
-        ntrode_probe_channel_map_fields = nwb_metadata.metadata['ntrode electrode group channel map'][0].keys()
+        ntrode_probe_channel_map_fields = nwb_metadata.metadata['ntrode_electrode_group_channel_map'][0].keys()
         self.assertIn('map', ntrode_probe_channel_map_fields)
         self.assertIn('electrode_group_id', ntrode_probe_channel_map_fields)
         self.assertIn('ntrode_id', ntrode_probe_channel_map_fields)

--- a/rec_to_nwb/test/processing/metadata/test_metadataManager.py
+++ b/rec_to_nwb/test/processing/metadata/test_metadataManager.py
@@ -26,7 +26,7 @@ class TestMetadataManager(TestCase):
         self.assertIn('institution', metadata_fields)
         self.assertIn('session_id', metadata_fields)
         self.assertIn('experiment_description', metadata_fields)
-        self.assertIn('session description', metadata_fields)
+        self.assertIn('session_description', metadata_fields)
         self.assertIn('subject', metadata_fields)
         self.assertIn('tasks', metadata_fields)
         self.assertIn('behavioral_events', metadata_fields)

--- a/rec_to_nwb/test/processing/res/jaq_metadata.yml
+++ b/rec_to_nwb/test/processing/res/jaq_metadata.yml
@@ -42,7 +42,7 @@ device:
   name:
     - Trodes
 
-electrode groups:
+electrode_groups:
   - id: 0
     location: mPFC
     device_type: 128c-4s8mm6cm-20um-40um-sl

--- a/rec_to_nwb/test/processing/res/jaq_metadata.yml
+++ b/rec_to_nwb/test/processing/res/jaq_metadata.yml
@@ -9,7 +9,7 @@ subject:
   genotype:        Wild Type
   sex:             Male
   species:         Rat
-  subject id:      Beans
+  subject_id:      Beans
   weight:          Unknown
 
 tasks:

--- a/rec_to_nwb/test/processing/res/jaq_metadata.yml
+++ b/rec_to_nwb/test/processing/res/jaq_metadata.yml
@@ -2,7 +2,7 @@ experimenter_name: Alison Comrie
 lab:               Loren Frank
 institution:       University of California, San Francisco
 experiment_description: Reinforcement learning
-session description: Reinforcement leaarning
+session_description: Reinforcement leaarning
 session_id:        jaq_01
 subject:
   description:     Long Evans Rat

--- a/rec_to_nwb/test/processing/res/jaq_metadata.yml
+++ b/rec_to_nwb/test/processing/res/jaq_metadata.yml
@@ -1,4 +1,4 @@
-experimenter name: Alison Comrie
+experimenter_name: Alison Comrie
 lab:               Loren Frank
 institution:       University of California, San Francisco
 experiment description: Reinforcement learning

--- a/rec_to_nwb/test/processing/res/jaq_metadata.yml
+++ b/rec_to_nwb/test/processing/res/jaq_metadata.yml
@@ -1,7 +1,7 @@
 experimenter_name: Alison Comrie
 lab:               Loren Frank
 institution:       University of California, San Francisco
-experiment description: Reinforcement learning
+experiment_description: Reinforcement learning
 session description: Reinforcement leaarning
 session_id:        jaq_01
 subject:

--- a/rec_to_nwb/test/processing/res/metadata.yml
+++ b/rec_to_nwb/test/processing/res/metadata.yml
@@ -16,7 +16,7 @@ units:
   analog: unspecified
   behavioral_events: unspecified
 
-data acq device:
+data_acq_device:
   - system: sample_system
     amplifier: sample_amplifier
     adc_circuit: sample_adc_circuit

--- a/rec_to_nwb/test/processing/res/metadata.yml
+++ b/rec_to_nwb/test/processing/res/metadata.yml
@@ -112,7 +112,7 @@ behavioral_events:
     name: Pump6
 
 
-electrode groups:
+electrode_groups:
   - id: 0
     location: mPFC
     device_type: 128c-4s8mm6cm-20um-40um-sl

--- a/rec_to_nwb/test/processing/res/metadata.yml
+++ b/rec_to_nwb/test/processing/res/metadata.yml
@@ -133,7 +133,7 @@ electrode_groups:
     units: 'um'
 
 
-ntrode electrode group channel map:
+ntrode_electrode_group_channel_map:
   - ntrode_id: 1
     electrode_group_id: 0
     bad_channels: [0,2]

--- a/rec_to_nwb/test/processing/res/metadata.yml
+++ b/rec_to_nwb/test/processing/res/metadata.yml
@@ -9,7 +9,7 @@ subject:
   genotype:        Wild Type
   sex:             M
   species:         Ratticus norvegicus
-  subject id:      Beans
+  subject_id:      Beans
   weight:          Unknown
 
 units:

--- a/rec_to_nwb/test/processing/res/metadata.yml
+++ b/rec_to_nwb/test/processing/res/metadata.yml
@@ -2,7 +2,7 @@ experimenter_name: Alison Comrie
 lab:               Loren Frank
 institution:       University of California, San Francisco
 experiment_description: Reinforcement learning
-session description: Reinforcement leaarning
+session_description: Reinforcement leaarning
 session_id:        beans_01
 subject:
   description:     Long Evans Rat

--- a/rec_to_nwb/test/processing/res/metadata.yml
+++ b/rec_to_nwb/test/processing/res/metadata.yml
@@ -1,7 +1,7 @@
 experimenter_name: Alison Comrie
 lab:               Loren Frank
 institution:       University of California, San Francisco
-experiment description: Reinforcement learning
+experiment_description: Reinforcement learning
 session description: Reinforcement leaarning
 session_id:        beans_01
 subject:

--- a/rec_to_nwb/test/processing/res/metadata.yml
+++ b/rec_to_nwb/test/processing/res/metadata.yml
@@ -1,4 +1,4 @@
-experimenter name: Alison Comrie
+experimenter_name: Alison Comrie
 lab:               Loren Frank
 institution:       University of California, San Francisco
 experiment description: Reinforcement learning

--- a/rec_to_nwb/test/processing/validators/test_nTrodeValidator.py
+++ b/rec_to_nwb/test/processing/validators/test_nTrodeValidator.py
@@ -43,7 +43,7 @@ class TestNTrodeValidator(TestCase):
         ]
 
         metadata = {
-            'electrode groups': [
+            'electrode_groups': [
                 {'id': 0, 'location': 'mPFC', 'device_type': 'tetrode_12.5', 'description': 'Probe 1'},
                 {'id': 1, 'location': 'mPFC', 'device_type': '128c-4s8mm6cm-20um-40um-sl', 'description': 'Probe 2'},
             ],
@@ -83,7 +83,7 @@ class TestNTrodeValidator(TestCase):
         ]
 
         metadata = {
-            'electrode groups': [
+            'electrode_groups': [
                 {'id': 0, 'location': 'mPFC', 'device_type': 'tetrode_12.5', 'description': 'Probe 1'},
             ],
             "ntrode electrode group channel map": [
@@ -125,7 +125,7 @@ class TestNTrodeValidator(TestCase):
         ]
 
         metadata = {
-            'electrode groups': [
+            'electrode_groups': [
                 {'id': 0, 'location': 'mPFC', 'device_type': 'tetrode_12.5', 'description': 'Probe 1'},
                 {'id': 1, 'location': 'mPFC', 'device_type': '128c-4s8mm6cm-20um-40um-sl', 'description': 'Probe 2'},
             ],
@@ -197,7 +197,7 @@ class TestNTrodeValidator(TestCase):
         ]
 
         metadata = {
-            'electrode groups': [
+            'electrode_groups': [
                 {'id': 0, 'location': 'mPFC', 'device_type': 'tetrode_12.5', 'description': 'Probe 1'},
                 {'id': 1, 'location': 'mPFC', 'device_type': '128c-4s8mm6cm-20um-40um-sl', 'description': 'Probe 2'},
             ],

--- a/rec_to_nwb/test/processing/validators/test_nTrodeValidator.py
+++ b/rec_to_nwb/test/processing/validators/test_nTrodeValidator.py
@@ -47,7 +47,7 @@ class TestNTrodeValidator(TestCase):
                 {'id': 0, 'location': 'mPFC', 'device_type': 'tetrode_12.5', 'description': 'Probe 1'},
                 {'id': 1, 'location': 'mPFC', 'device_type': '128c-4s8mm6cm-20um-40um-sl', 'description': 'Probe 2'},
             ],
-            "ntrode electrode group channel map": [
+            "ntrode_electrode_group_channel_map": [
                 {"ntrode_id": 1, "electrode_group_id": 0, "bad_channels": [0, 2], "map": {0: 0, 1: 1, 2: 2, 3: 3}},
                 {"ntrode_id": 2, "electrode_group_id": 1, "bad_channels": [0, 1], "map": {0: 4, 1: 5, 2: 6, 3: 7}},
             ]
@@ -86,7 +86,7 @@ class TestNTrodeValidator(TestCase):
             'electrode_groups': [
                 {'id': 0, 'location': 'mPFC', 'device_type': 'tetrode_12.5', 'description': 'Probe 1'},
             ],
-            "ntrode electrode group channel map": [
+            "ntrode_electrode_group_channel_map": [
                 {"ntrode_id": 1, "electrode_group_id": 0, "bad_channels": [0, 2], "map": {0: 0, 1: 1, 2: 2, 3: 3}},
             ]
         }
@@ -129,7 +129,7 @@ class TestNTrodeValidator(TestCase):
                 {'id': 0, 'location': 'mPFC', 'device_type': 'tetrode_12.5', 'description': 'Probe 1'},
                 {'id': 1, 'location': 'mPFC', 'device_type': '128c-4s8mm6cm-20um-40um-sl', 'description': 'Probe 2'},
             ],
-            "ntrode electrode group channel map": [
+            "ntrode_electrode_group_channel_map": [
                 {"ntrode_id": 1, "electrode_group_id": 0, "bad_channels": [0, 2], "map": {0: 0, 1: 1, 2: 2, 3: 3}},
                 {"ntrode_id": 2, "electrode_group_id": 1, "bad_channels": [0, 1], "map": {0: 4, 1: 5, 2: 6, 3: 7}},
                 {"ntrode_id": 3, "electrode_group_id": 0, "bad_channels": [0, 2], "map": {0: 8, 1: 9, 2: 10, 3: 11}},
@@ -144,7 +144,7 @@ class TestNTrodeValidator(TestCase):
 
     @should_raise(TypeError)
     def test_ntrode_validator_raise_exception_due_to_empty_param(self):
-        metadata = {"ntrode electrode group channel map": [
+        metadata = {"ntrode_electrode_group_channel_map": [
             {"ntrode_id": 1, "electrode_group_id": 0, "bad_channels": [0, 2], "map": {0: 0, 1: 1, 2: 2, 3: 3}},
             {"ntrode_id": 2, "electrode_group_id": 0, "bad_channels": [0, 1], "map": {0: 4, 1: 5, 2: 6, 3: 7}},
             {"ntrode_id": 3, "electrode_group_id": 0, "bad_channels": [0, 2], "map": {0: 8, 1: 9, 2: 10, 3: 11}},
@@ -154,7 +154,7 @@ class TestNTrodeValidator(TestCase):
 
     @should_raise(InvalidHeaderException)
     def test_ntrode_validator_raise_exception_due_to_header_without_spike_ntrodes(self):
-        metadata = {"ntrode electrode group channel map": [
+        metadata = {"ntrode_electrode_group_channel_map": [
             {"ntrode_id": 1, "electrode_group_id": 0, "bad_channels": [0, 2], "map": {0: 0, 1: 1, 2: 2, 3: 3}},
             {"ntrode_id": 2, "electrode_group_id": 0, "bad_channels": [0, 1], "map": {0: 4, 1: 5, 2: 6, 3: 7}},
             {"ntrode_id": 3, "electrode_group_id": 0, "bad_channels": [0, 2], "map": {0: 8, 1: 9, 2: 10, 3: 11}},
@@ -166,7 +166,7 @@ class TestNTrodeValidator(TestCase):
 
     @should_raise(InvalidMetadataException)
     def test_should_raise_exception_due_to_metadata_without_ntrodes(self):
-        metadata = {"ntrode electrode group channel map": []}
+        metadata = {"ntrode_electrode_group_channel_map": []}
 
         validator = NTrodeValidator(metadata, self.header, [])
         validator.create_summary()
@@ -201,7 +201,7 @@ class TestNTrodeValidator(TestCase):
                 {'id': 0, 'location': 'mPFC', 'device_type': 'tetrode_12.5', 'description': 'Probe 1'},
                 {'id': 1, 'location': 'mPFC', 'device_type': '128c-4s8mm6cm-20um-40um-sl', 'description': 'Probe 2'},
             ],
-            "ntrode electrode group channel map": [
+            "ntrode_electrode_group_channel_map": [
                 {"ntrode_id": 1, "electrode_group_id": 0, "bad_channels": [0, 2], "map": {0: 0, 1: 1, 2: 2, 3: 3}},
                 {"ntrode_id": 2, "electrode_group_id": 1, "bad_channels": [0, 1], "map": {0: 4, 1: 5, 2: 6, 3: 7}},
             ]


### PR DESCRIPTION
Several fields in the yaml file use blank spaces between words instead of underscores.