### PR TITLE
Skip MCU_IO binaries and alert user

### DIFF
--- a/rec_to_nwb/processing/nwb/components/dio/dio_files.py
+++ b/rec_to_nwb/processing/nwb/components/dio/dio_files.py
@@ -25,6 +25,11 @@ class DioFiles:
     def __get_dict(cls, directory):
         dio_dict = {}
         for file in glob.glob(os.path.join(directory, '*.dat')):
-            dio_name = file.split('.')[-2].split('_')[-1]
-            dio_dict[dio_name] = os.path.join(directory, file)
+            if file.split('.')[-2].split('_')[-2] == "MCU":
+                # To avoid this warning, remove MCU_IO data from being displayed via the .trodesconf, this will stop MCU_IO extraction
+                print(f'WARNING: MCU_IO data are not currently handled by rec_to_nwb. Skipping file: {file}.')
+                # TODO: find MCU_IO binaries if they exist and appropriately insert these data into nwbs in future version of rec_to_nwb
+            else:
+                dio_name = file.split('.')[-2].split('_')[-1] # This string should be of the form "Din12" "Dout5"
+                dio_dict[dio_name] = os.path.join(directory, file)
         return dio_dict


### PR DESCRIPTION
We currently do not use MCU_IO data in the lab, but it is possible to extract these empty data streams from .rec files. If they have been extracted during preprocessing, we should not mix them up with our standard ECU DIOs. They are named similarly - for ex, ending in "MCU_Din3.dat" versus ending in just "Din3.dat" - so future version of rec_to_nwb should appropriately find MCU_IOs and incorporate those data in nwb files. In the interm, this fix enables us to skip MCU_IOs, alert the user, and look only for ECU DIOs here. Without this, MCU_IO binaries can incorrectly get matched up to ECU DIO names, causing errors in the data inserted in the nwb file. This fix enables finding only the ECU DIO data and matching them to the appropriate ECU DIO names. The change has been tested locally.