### PR TITLE
Fix analog name overlap

### DIFF
--- a/rec_to_nwb/processing/nwb/components/analog/analog_files.py
+++ b/rec_to_nwb/processing/nwb/components/analog/analog_files.py
@@ -3,7 +3,6 @@ import os
 
 
 class AnalogFiles:
-
     def __init__(self, directories):
         self.directories = directories
 
@@ -13,7 +12,10 @@ class AnalogFiles:
     @classmethod
     def __get_dict(cls, directory):
         analog_dict = {}
-        for file in glob.glob(os.path.join(directory, '*.dat')):
-            analog_name = file.split('.')[-2].split('_')[-1]
+        for file in glob.glob(os.path.join(directory, "*.dat")):
+            if "timestamps" in file:
+                analog_name = "timestamps"
+            else:
+                analog_name = file.split(".")[-2]
             analog_dict[analog_name] = os.path.join(directory, file)
         return analog_dict

--- a/rec_to_nwb/processing/nwb/components/analog/fl_analog_manager.py
+++ b/rec_to_nwb/processing/nwb/components/analog/fl_analog_manager.py
@@ -30,7 +30,7 @@ class FlAnalogManager:
 
     @beartype
     def get_analog(self) -> FlAnalog:
-        """ "extract data from analog files"""
+        """extract data from analog files"""
 
         all_analog_data = []
         number_of_datasets = len(self.analog_files)

--- a/rec_to_nwb/processing/nwb/components/analog/fl_analog_manager.py
+++ b/rec_to_nwb/processing/nwb/components/analog/fl_analog_manager.py
@@ -1,24 +1,27 @@
 import numpy as np
 from rec_to_nwb.processing.nwb.components.analog.fl_analog import FlAnalog
-from rec_to_nwb.processing.nwb.components.analog.fl_analog_builder import \
-    FlAnalogBuilder
-from rec_to_nwb.processing.nwb.components.analog.fl_analog_extractor import \
-    FlAnalogExtractor
+from rec_to_nwb.processing.nwb.components.analog.fl_analog_builder import (
+    FlAnalogBuilder,
+)
+from rec_to_nwb.processing.nwb.components.analog.fl_analog_extractor import (
+    FlAnalogExtractor,
+)
 from rec_to_nwb.processing.tools.beartype.beartype import beartype
-from rec_to_nwb.processing.tools.validate_parameters import \
-    validate_parameters_equal_length
+from rec_to_nwb.processing.tools.validate_parameters import (
+    validate_parameters_equal_length,
+)
 
 
 class FlAnalogManager:
-
     @beartype
-    def __init__(self, analog_files: list,
-                 continuous_time_files: list,
-                 convert_timestamps: bool = True,
-                 return_timestamps: bool = True,
-                 ):
-        validate_parameters_equal_length(
-            __name__, analog_files, continuous_time_files)
+    def __init__(
+        self,
+        analog_files: list,
+        continuous_time_files: list,
+        convert_timestamps: bool = True,
+        return_timestamps: bool = True,
+    ):
+        validate_parameters_equal_length(__name__, analog_files, continuous_time_files)
 
         self.analog_files = analog_files
         self.continuous_time_files = continuous_time_files
@@ -27,7 +30,7 @@ class FlAnalogManager:
 
     @beartype
     def get_analog(self) -> FlAnalog:
-        """"extract data from analog files"""
+        """ "extract data from analog files"""
 
         all_analog_data = []
         number_of_datasets = len(self.analog_files)
@@ -36,7 +39,7 @@ class FlAnalogManager:
                 FlAnalogExtractor.extract_analog_for_single_dataset(
                     self.analog_files[i],
                     self.continuous_time_files[i],
-                    convert_timestamps=self.convert_timestamps
+                    convert_timestamps=self.convert_timestamps,
                 )
             )
         merged_epochs = self.__merge_epochs(all_analog_data)
@@ -55,21 +58,26 @@ class FlAnalogManager:
         for single_dataset_data in data_from_multiple_datasets[1:]:
             for row in single_dataset_data.keys():
                 merged_epochs[row] = np.hstack(
-                    (merged_epochs[row], single_dataset_data[row]))
+                    (merged_epochs[row], single_dataset_data[row])
+                )
         return merged_epochs
 
     @staticmethod
     def __merge_row_description(data_from_multiple_datasets):
         row_ids = data_from_multiple_datasets[0].keys()
-        description = ''
+        description = ""
         for id in row_ids:
-            description += id + '   '
+            if "timestamp" not in id:
+                description += id + "   "
         return description
 
     @classmethod
     def __merge_analog_sensors(cls, merged_epochs):
-        analog_sensors = [merged_epochs[analog_sensor] for analog_sensor in merged_epochs.keys() if
-                          'timestamp' not in analog_sensor]
+        analog_sensors = [
+            merged_epochs[analog_sensor]
+            for analog_sensor in merged_epochs.keys()
+            if "timestamp" not in analog_sensor
+        ]
         merged_analog_sensors = np.array(analog_sensors, np.int32)
         transposed_analog_data = np.ndarray.transpose(merged_analog_sensors)
         return transposed_analog_data
@@ -77,5 +85,5 @@ class FlAnalogManager:
     @classmethod
     def __get_timestamps(cls, merged_epochs):
         for analog_sensor in merged_epochs.keys():
-            if 'timestamps' in analog_sensor:
+            if "timestamps" in analog_sensor:
                 return merged_epochs[analog_sensor]


### PR DESCRIPTION
Fix issue where key names would prevent similarly named analog channels from both being inserted into nwb (e.g. `ECU_Ain1` and `CONTROLLER_Ain1`).  Remove "timestamps" name from behavioral events description since it is not inserted as one of the columns.